### PR TITLE
update error log interface

### DIFF
--- a/http_test.go
+++ b/http_test.go
@@ -1,0 +1,82 @@
+package sawmill
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHTTPErrorLog(t *testing.T) {
+	// Create a buffer to capture log output
+	var buf bytes.Buffer
+	
+	// Create a logger with text handler writing to buffer
+	handler := NewTextHandler(WithWriter(&buf))
+	logger := New(handler)
+	
+	// Create HTTP server with sawmill error log
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+	
+	server := &http.Server{
+		Addr:     ":0",
+		Handler:  mux,
+		ErrorLog: logger.HTTPErrorLog(),
+	}
+	
+	// Test that the HTTPErrorLog method returns a valid *log.Logger
+	if server.ErrorLog == nil {
+		t.Fatal("HTTPErrorLog() returned nil")
+	}
+	
+	// Simulate an HTTP error by calling the error logger directly
+	server.ErrorLog.Println("test http error message")
+	
+	// Check that the message was logged
+	output := buf.String()
+	if !strings.Contains(output, "test http error message") {
+		t.Errorf("Expected log output to contain 'test http error message', got: %s", output)
+	}
+	
+	// Check that it's logged at ERROR level
+	if !strings.Contains(output, "ERROR") {
+		t.Errorf("Expected log output to contain 'ERROR' level, got: %s", output)
+	}
+}
+
+func TestHTTPErrorLogWithRealServer(t *testing.T) {
+	// Create a buffer to capture log output
+	var buf bytes.Buffer
+	
+	// Create a logger with text handler writing to buffer
+	handler := NewTextHandler(WithWriter(&buf))
+	logger := New(handler)
+	
+	// Create HTTP server with intentionally broken handler to trigger error
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		// This should work fine and not generate errors
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("OK"))
+	})
+	
+	server := httptest.NewServer(mux)
+	server.Config.ErrorLog = logger.HTTPErrorLog()
+	defer server.Close()
+	
+	// Make a request to ensure server works
+	resp, err := http.Get(server.URL)
+	if err != nil {
+		t.Fatalf("Failed to make request: %v", err)
+	}
+	defer resp.Body.Close()
+	
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status 200, got %d", resp.StatusCode)
+	}
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -3,6 +3,7 @@ package sawmill
 import (
 	"context"
 	"io"
+	"log"
 	"log/slog"
 	"time"
 )
@@ -108,6 +109,7 @@ type Logger interface {
 	SetHandler(handler Handler)
 	Handler() Handler
 	As(formatter Formatter) AsLogger
+	HTTPErrorLog() *log.Logger
 }
 
 // AsLogger provides temporary format switching for single messages


### PR DESCRIPTION
This pull request introduces functionality to integrate the `sawmill` logging library with `http.Server.ErrorLog`, enabling HTTP error logging using `sawmill`. It includes changes to the `Logger` interface, the `logger` implementation, and new tests to validate the feature.

### New functionality for HTTP error logging:

* **`interfaces.go`:** Added a new method `HTTPErrorLog()` to the `Logger` interface, which returns a `*log.Logger` compatible with `http.Server.ErrorLog`.
* **`logger.go`:** Implemented the `HTTPErrorLog()` method in the `logger` struct, along with the `httpErrorLogWriter` type to adapt `sawmill` for standard HTTP error logging.

### Testing:

* **`http_test.go`:** Added comprehensive tests for the `HTTPErrorLog()` method, including scenarios to verify log output and integration with a real HTTP server.

### Dependency updates:

* **`interfaces.go` and `logger.go`:** Added the `log` package to imports to support the new functionality. [[1]](diffhunk://#diff-b7b79f1ac09ee75185e8a967df69488f9fe9597d89aaa80d50296d9c028ee7d9R6) [[2]](diffhunk://#diff-ff87b7c4777a35588053a509583d66c9f404ccbea9e1c71d2a5f224d7ad1323eR8)