### PR TITLE
add tests with masking

### DIFF
--- a/examples/http-plugin/main.go
+++ b/examples/http-plugin/main.go
@@ -350,7 +350,7 @@ func main() {
 	time.Sleep(500 * time.Millisecond)
 
 	// Make test requests
-	fmt.Println("\nMaking test requests...\n")
+	fmt.Println("\nMaking test requests...")
 	makeTestRequests()
 
 	// Shutdown server

--- a/examples/masking/main.go
+++ b/examples/masking/main.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"github.com/bresrch/sawmill"
+)
+
+// Example structs demonstrating masking functionality
+type User struct {
+	Name      string `sawmill:""`           // No masking
+	Email     string `sawmill:"mask[3]"`    // Show first 3 characters
+	Password  string `sawmill:"mask"`       // Fully masked
+	APIKey    string `sawmill:"mask[8]"`    // Show first 8 characters
+	Token     string `sawmill:"mask[0]"`    // Fully masked (equivalent to "mask")
+	ID        int    `sawmill:"mask[2]"`    // Show first 2 digits
+}
+
+type Session struct {
+	UserID    int    `sawmill:"mask[1]"`
+	SessionID string `sawmill:"mask"`
+	User      User   // Nested struct with its own masking rules
+}
+
+func main() {
+	// Create a logger with JSON output for clear visibility
+	logger := sawmill.New(sawmill.NewJSONHandler(
+		sawmill.WithPrettyPrint(true),
+	))
+
+	// Example user data
+	user := User{
+		Name:     "John Doe",
+		Email:    "john.doe@example.com",
+		Password: "super_secret_password",
+		APIKey:   "sk_live_abc123def456ghi789",
+		Token:    "very_secret_token_xyz",
+		ID:       12345,
+	}
+
+	// Log user information - sensitive fields will be masked
+	logger.Info("User logged in", "user", user)
+
+	// Example with nested structs
+	session := Session{
+		UserID:    67890,
+		SessionID: "session_abc123xyz789",
+		User:      user,
+	}
+
+	logger.Info("Session created", "session", session)
+
+	// Example with text formatter
+	textLogger := sawmill.New(sawmill.NewTextHandler())
+	textLogger.Info("User details (text format)", "user", user)
+
+	// Example with key-value formatter
+	kvLogger := sawmill.New(sawmill.NewKeyValueHandler())
+	kvLogger.Info("User details (key-value format)", "user", user)
+}

--- a/flat_attributes_test.go
+++ b/flat_attributes_test.go
@@ -1,0 +1,472 @@
+package sawmill
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestFlatAttributesBasicOperations(t *testing.T) {
+	attrs := NewFlatAttributes()
+
+	// Test Set and Get
+	attrs.Set([]string{"key1"}, "value1")
+	attrs.Set([]string{"nested", "key2"}, "value2")
+
+	value1, ok1 := attrs.Get([]string{"key1"})
+	if !ok1 || value1 != "value1" {
+		t.Errorf("Expected 'value1', got %v, %v", value1, ok1)
+	}
+
+	value2, ok2 := attrs.Get([]string{"nested", "key2"})
+	if !ok2 || value2 != "value2" {
+		t.Errorf("Expected 'value2', got %v, %v", value2, ok2)
+	}
+
+	// Test non-existent key
+	nonExistent, ok3 := attrs.Get([]string{"nonexistent"})
+	if ok3 || nonExistent != nil {
+		t.Errorf("Expected nil and false for non-existent key, got %v, %v", nonExistent, ok3)
+	}
+}
+
+func TestFlatAttributesSetFast(t *testing.T) {
+	attrs := NewFlatAttributes()
+
+	attrs.SetFast("key1", "value1")
+	attrs.SetFast("key2", 42)
+
+	value1, ok1 := attrs.Get([]string{"key1"})
+	if !ok1 || value1 != "value1" {
+		t.Errorf("Expected 'value1', got %v, %v", value1, ok1)
+	}
+
+	value2, ok2 := attrs.Get([]string{"key2"})
+	if !ok2 || value2 != 42 {
+		t.Errorf("Expected 42, got %v, %v", value2, ok2)
+	}
+}
+
+func TestFlatAttributesSetByDotNotation(t *testing.T) {
+	attrs := NewFlatAttributes()
+
+	attrs.SetByDotNotation("user.profile.name", "John Doe")
+	attrs.SetByDotNotation("user.profile.age", 30)
+	attrs.SetByDotNotation("system.version", "1.0")
+
+	name, ok1 := attrs.Get([]string{"user", "profile", "name"})
+	if !ok1 || name != "John Doe" {
+		t.Errorf("Expected 'John Doe', got %v, %v", name, ok1)
+	}
+
+	age, ok2 := attrs.Get([]string{"user", "profile", "age"})
+	if !ok2 || age != 30 {
+		t.Errorf("Expected 30, got %v, %v", age, ok2)
+	}
+
+	version, ok3 := attrs.Get([]string{"system", "version"})
+	if !ok3 || version != "1.0" {
+		t.Errorf("Expected '1.0', got %v, %v", version, ok3)
+	}
+}
+
+func TestFlatAttributesIsEmpty(t *testing.T) {
+	attrs := NewFlatAttributes()
+
+	if !attrs.IsEmpty() {
+		t.Error("New FlatAttributes should be empty")
+	}
+
+	attrs.SetFast("key", "value")
+
+	if attrs.IsEmpty() {
+		t.Error("FlatAttributes should not be empty after adding value")
+	}
+}
+
+func TestFlatAttributesClone(t *testing.T) {
+	attrs := NewFlatAttributes()
+	attrs.Set([]string{"key1"}, "value1")
+	attrs.Set([]string{"nested", "key2"}, "value2")
+
+	cloned := attrs.Clone()
+
+	// Test that cloned has same values
+	value1, ok1 := cloned.Get([]string{"key1"})
+	if !ok1 || value1 != "value1" {
+		t.Errorf("Cloned attrs should have same value1, got %v, %v", value1, ok1)
+	}
+
+	// Test that modifications to original don't affect clone
+	attrs.Set([]string{"key1"}, "modified")
+	clonedValue1, ok2 := cloned.Get([]string{"key1"})
+	if !ok2 || clonedValue1 != "value1" {
+		t.Errorf("Clone should be independent, got %v, %v", clonedValue1, ok2)
+	}
+
+	// Test that modifications to clone don't affect original
+	cloned.Set([]string{"key3"}, "new")
+	originalKey3, ok3 := attrs.Get([]string{"key3"})
+	if ok3 || originalKey3 != nil {
+		t.Errorf("Original should not have new key from clone, got %v, %v", originalKey3, ok3)
+	}
+}
+
+func TestFlatAttributesMerge(t *testing.T) {
+	attrs1 := NewFlatAttributes()
+	attrs1.Set([]string{"key1"}, "value1")
+	attrs1.Set([]string{"nested", "key2"}, "value2")
+
+	attrs2 := NewFlatAttributes()
+	attrs2.Set([]string{"key3"}, "value3")
+	attrs2.Set([]string{"nested", "key4"}, "value4")
+
+	attrs1.Merge(attrs2)
+
+	// Check that attrs1 now has all values
+	if val, ok := attrs1.Get([]string{"key1"}); !ok || val != "value1" {
+		t.Error("Merge should preserve original values")
+	}
+	if val, ok := attrs1.Get([]string{"key3"}); !ok || val != "value3" {
+		t.Error("Merge should add new values")
+	}
+	if val, ok := attrs1.Get([]string{"nested", "key2"}); !ok || val != "value2" {
+		t.Error("Merge should preserve nested original values")
+	}
+	if val, ok := attrs1.Get([]string{"nested", "key4"}); !ok || val != "value4" {
+		t.Error("Merge should add nested new values")
+	}
+}
+
+func TestFlatAttributesWalk(t *testing.T) {
+	attrs := NewFlatAttributes()
+	attrs.Set([]string{"key1"}, "value1")
+	attrs.Set([]string{"nested", "key2"}, "value2")
+	attrs.Set([]string{"deep", "nested", "key3"}, "value3")
+
+	visited := make(map[string]interface{})
+	attrs.Walk(func(path []string, value interface{}) {
+		key := strings.Join(path, ".")
+		visited[key] = value
+	})
+
+	expected := map[string]interface{}{
+		"key1":             "value1",
+		"nested.key2":      "value2",
+		"deep.nested.key3": "value3",
+	}
+
+	if !reflect.DeepEqual(visited, expected) {
+		t.Errorf("Walk visited %v, expected %v", visited, expected)
+	}
+}
+
+func TestFlatAttributesToNestedMap(t *testing.T) {
+	attrs := NewFlatAttributes()
+	attrs.Set([]string{"key1"}, "value1")
+	attrs.Set([]string{"user", "name"}, "John")
+	attrs.Set([]string{"user", "age"}, 30)
+	attrs.Set([]string{"user", "profile", "email"}, "john@example.com")
+
+	nested := attrs.ToNestedMap()
+
+	// Check top-level key
+	if nested["key1"] != "value1" {
+		t.Errorf("Expected key1=value1, got %v", nested["key1"])
+	}
+
+	// Check nested user object
+	user, ok := nested["user"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected user to be a map, got %T", nested["user"])
+	}
+
+	if user["name"] != "John" {
+		t.Errorf("Expected user.name=John, got %v", user["name"])
+	}
+	if user["age"] != 30 {
+		t.Errorf("Expected user.age=30, got %v", user["age"])
+	}
+
+	// Check deeply nested profile
+	profile, ok := user["profile"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("Expected user.profile to be a map, got %T", user["profile"])
+	}
+
+	if profile["email"] != "john@example.com" {
+		t.Errorf("Expected user.profile.email=john@example.com, got %v", profile["email"])
+	}
+}
+
+func TestFlatAttributesExpandStruct(t *testing.T) {
+	attrs := NewFlatAttributes()
+
+	type Address struct {
+		Street string `json:"street"`
+		City   string `json:"city"`
+		Zip    int    `json:"zip"`
+	}
+
+	type User struct {
+		ID      int     `json:"id"`
+		Name    string  `json:"name"`
+		Address Address `json:"address"`
+		Active  bool    `json:"active"`
+	}
+
+	user := User{
+		ID:   123,
+		Name: "John Doe",
+		Address: Address{
+			Street: "123 Main St",
+			City:   "Anytown",
+			Zip:    12345,
+		},
+		Active: true,
+	}
+
+	attrs.ExpandStruct("user", user)
+
+	// Check expanded fields
+	tests := []struct {
+		path     []string
+		expected interface{}
+	}{
+		{[]string{"user", "id"}, 123},
+		{[]string{"user", "name"}, "John Doe"},
+		{[]string{"user", "address", "street"}, "123 Main St"},
+		{[]string{"user", "address", "city"}, "Anytown"},
+		{[]string{"user", "address", "zip"}, 12345},
+		{[]string{"user", "active"}, true},
+	}
+
+	for _, test := range tests {
+		value, ok := attrs.Get(test.path)
+		if !ok || value != test.expected {
+			t.Errorf("Expected %v at path %v, got %v, %v", test.expected, test.path, value, ok)
+		}
+	}
+}
+
+func TestFlatAttributesExpandStructWithPointer(t *testing.T) {
+	attrs := NewFlatAttributes()
+
+	type User struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+
+	user := &User{ID: 456, Name: "Jane Doe"}
+
+	attrs.ExpandStruct("user", user)
+
+	// Check expanded fields from pointer
+	if val, ok := attrs.Get([]string{"user", "id"}); !ok || val != 456 {
+		t.Errorf("Expected user.id=456, got %v, %v", val, ok)
+	}
+	if val, ok := attrs.Get([]string{"user", "name"}); !ok || val != "Jane Doe" {
+		t.Errorf("Expected user.name=Jane Doe, got %v, %v", val, ok)
+	}
+}
+
+func TestFlatAttributesMarshalJSON(t *testing.T) {
+	attrs := NewFlatAttributes()
+	attrs.Set([]string{"key1"}, "value1")
+	attrs.Set([]string{"user", "name"}, "John")
+	attrs.Set([]string{"user", "age"}, 30)
+
+	data, err := attrs.MarshalJSON()
+	if err != nil {
+		t.Fatalf("MarshalJSON failed: %v", err)
+	}
+
+	jsonStr := string(data)
+
+	// Check that all values are present in JSON
+	if !strings.Contains(jsonStr, `"key1":"value1"`) {
+		t.Errorf("Expected key1 in JSON: %s", jsonStr)
+	}
+	if !strings.Contains(jsonStr, `"user.name":"John"`) {
+		t.Errorf("Expected user.name in JSON: %s", jsonStr)
+	}
+	if !strings.Contains(jsonStr, `"user.age":30`) {
+		t.Errorf("Expected user.age in JSON: %s", jsonStr)
+	}
+}
+
+func TestFlatAttributesMaskingFunctionality(t *testing.T) {
+	attrs := NewFlatAttributes()
+
+	// Test maskValue function with different mask tags
+	tests := []struct {
+		input    interface{}
+		maskTag  string
+		expected string
+	}{
+		{"password123", "mask", "***********"},
+		{"email@test.com", "mask[5]", "email*********"},
+		{"short", "mask[10]", "short"}, // unmask count >= length
+		{12345, "mask[2]", "12***"},
+		{"", "mask", ""},
+		{"test", "mask[0]", "****"},
+		{"invalid", "invalid_tag", "invalid"},
+		{"test", "", "test"},
+	}
+
+	for i, test := range tests {
+		result := attrs.maskValue(test.input, test.maskTag)
+		if result != test.expected {
+			t.Errorf("Test %d: maskValue(%v, %s) = %v, expected %v",
+				i, test.input, test.maskTag, result, test.expected)
+		}
+	}
+}
+
+func TestFlatAttributesStructWithMaskTags(t *testing.T) {
+	attrs := NewFlatAttributes()
+
+	type UserCredentials struct {
+		Username string `json:"username"`
+		Password string `json:"password" sawmill:"mask"`
+		Email    string `json:"email" sawmill:"mask[4]"`
+		APIKey   string `json:"api_key" sawmill:"mask[8]"`
+	}
+
+	creds := UserCredentials{
+		Username: "johndoe",
+		Password: "secret123",
+		Email:    "john@example.com",
+		APIKey:   "abc123def456ghi789",
+	}
+
+	attrs.ExpandStruct("creds", creds)
+
+	// Check that password is masked
+	password, ok1 := attrs.Get([]string{"creds", "password"})
+	if !ok1 || password != "*********" {
+		t.Errorf("Expected masked password, got %v, %v", password, ok1)
+	}
+
+	// Check that email shows first 4 characters
+	email, ok2 := attrs.Get([]string{"creds", "email"})
+	if !ok2 || email != "john************" {
+		t.Errorf("Expected email with first 4 chars, got %v, %v", email, ok2)
+	}
+
+	// Check that API key shows first 8 characters
+	apiKey, ok3 := attrs.Get([]string{"creds", "apikey"})
+	if !ok3 || apiKey != "abc123de**********" {
+		t.Errorf("Expected API key with first 8 chars, got %v, %v", apiKey, ok3)
+	}
+
+	// Check that username is not masked
+	username, ok4 := attrs.Get([]string{"creds", "username"})
+	if !ok4 || username != "johndoe" {
+		t.Errorf("Expected unmasked username, got %v, %v", username, ok4)
+	}
+}
+
+func TestFlatAttributesEdgeCases(t *testing.T) {
+	attrs := NewFlatAttributes()
+
+	// Test with nil value
+	attrs.Set([]string{"nil_key"}, nil)
+	nilValue, ok1 := attrs.Get([]string{"nil_key"})
+	if !ok1 || nilValue != nil {
+		t.Errorf("Expected nil value, got %v, %v", nilValue, ok1)
+	}
+
+	// Test with empty path - should be ignored by Set method
+	attrs.Set([]string{}, "empty_path")
+	emptyPathValue, ok2 := attrs.Get([]string{})
+	if ok2 || emptyPathValue != nil {
+		t.Errorf("Expected empty path to be ignored, got %v, %v", emptyPathValue, ok2)
+	}
+
+	// Test with path containing empty strings
+	attrs.Set([]string{"", "empty", ""}, "value")
+	emptyStringValue, ok3 := attrs.Get([]string{"", "empty", ""})
+	if !ok3 || emptyStringValue != "value" {
+		t.Errorf("Expected value with empty string path, got %v, %v", emptyStringValue, ok3)
+	}
+}
+
+func TestFlatAttributesConcurrentAccess(t *testing.T) {
+	attrs := NewFlatAttributes()
+
+	// Test concurrent writes and reads
+	done := make(chan bool, 2)
+
+	// Writer goroutine
+	go func() {
+		for i := 0; i < 100; i++ {
+			attrs.SetFast("key", i)
+		}
+		done <- true
+	}()
+
+	// Reader goroutine
+	go func() {
+		for i := 0; i < 100; i++ {
+			attrs.Get([]string{"key"})
+		}
+		done <- true
+	}()
+
+	// Wait for both goroutines
+	<-done
+	<-done
+
+	// Should not panic or race
+}
+
+func TestFlatAttributesLargeDataset(t *testing.T) {
+	attrs := NewFlatAttributes()
+
+	// Add many attributes
+	for i := 0; i < 1000; i++ {
+		key := []string{"batch", "item", fmt.Sprintf("item_%d", i)}
+		attrs.Set(key, i)
+	}
+
+	// Verify some random values
+	if val, ok := attrs.Get([]string{"batch", "item", "item_0"}); !ok || val != 0 {
+		t.Error("Expected first item to be 0")
+	}
+
+	// Test walk performance with large dataset
+	count := 0
+	attrs.Walk(func(path []string, value interface{}) {
+		count++
+	})
+
+	if count != 1000 {
+		t.Errorf("Expected to walk 1000 items, got %d", count)
+	}
+}
+
+func TestFlatAttributesSpecialCharacters(t *testing.T) {
+	attrs := NewFlatAttributes()
+
+	// Test with special characters in keys and values
+	attrs.Set([]string{"key with spaces"}, "value with spaces")
+	attrs.Set([]string{"key.with.dots"}, "value.with.dots")
+	attrs.Set([]string{"key/with/slashes"}, "value/with/slashes")
+	attrs.Set([]string{"key\"with\"quotes"}, "value\"with\"quotes")
+
+	// Verify all values are preserved
+	if val, ok := attrs.Get([]string{"key with spaces"}); !ok || val != "value with spaces" {
+		t.Error("Failed to handle spaces in key/value")
+	}
+	if val, ok := attrs.Get([]string{"key.with.dots"}); !ok || val != "value.with.dots" {
+		t.Error("Failed to handle dots in key/value")
+	}
+	if val, ok := attrs.Get([]string{"key/with/slashes"}); !ok || val != "value/with/slashes" {
+		t.Error("Failed to handle slashes in key/value")
+	}
+	if val, ok := attrs.Get([]string{"key\"with\"quotes"}); !ok || val != "value\"with\"quotes" {
+		t.Error("Failed to handle quotes in key/value")
+	}
+}

--- a/formatters_test.go
+++ b/formatters_test.go
@@ -1,0 +1,532 @@
+package sawmill
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestJSONFormatter(t *testing.T) {
+	formatter := NewJSONFormatter()
+	
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	record.Time = time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	record.Attributes.SetFast("key", "value")
+
+	data, err := formatter.Format(record)
+	if err != nil {
+		t.Fatalf("JSONFormatter.Format failed: %v", err)
+	}
+
+	output := string(data)
+	if !strings.Contains(output, `"message":"Test message"`) {
+		t.Errorf("Expected message in JSON output: %s", output)
+	}
+	if !strings.Contains(output, `"level":"INFO"`) {
+		t.Errorf("Expected level in JSON output: %s", output)
+	}
+	if !strings.Contains(output, `"key":"value"`) {
+		t.Errorf("Expected attributes in JSON output: %s", output)
+	}
+}
+
+func TestJSONFormatterPrettyPrint(t *testing.T) {
+	formatter := NewJSONFormatter()
+	formatter.PrettyPrint = true
+	
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	record.Time = time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	data, err := formatter.Format(record)
+	if err != nil {
+		t.Fatalf("JSONFormatter.Format with pretty print failed: %v", err)
+	}
+
+	output := string(data)
+	// Pretty printed JSON should have indentation
+	if !strings.Contains(output, "  ") {
+		t.Errorf("Expected indented JSON output: %s", output)
+	}
+}
+
+func TestJSONFormatterWithColors(t *testing.T) {
+	colorMappings := map[string]string{
+		"user": "\033[32m", // green
+	}
+	formatter := NewJSONFormatterWithColors(colorMappings)
+	formatter.ColorOutput = true
+	
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	record.Attributes.SetFast("user", "john")
+
+	data, err := formatter.Format(record)
+	if err != nil {
+		t.Fatalf("JSONFormatter.Format with colors failed: %v", err)
+	}
+
+	output := string(data)
+	// Should contain ANSI color codes
+	if !strings.Contains(output, "\033[") {
+		t.Errorf("Expected colored output: %s", output)
+	}
+}
+
+func TestJSONFormatterWithCustomAttributesKey(t *testing.T) {
+	formatter := NewJSONFormatterWithKey("custom_attrs")
+	
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	record.Attributes.SetFast("key", "value")
+
+	data, err := formatter.Format(record)
+	if err != nil {
+		t.Fatalf("JSONFormatter.Format with custom key failed: %v", err)
+	}
+
+	output := string(data)
+	if !strings.Contains(output, `"custom_attrs":`) {
+		t.Errorf("Expected custom attributes key in output: %s", output)
+	}
+}
+
+func TestJSONFormatterContentType(t *testing.T) {
+	formatter := NewJSONFormatter()
+	if formatter.ContentType() != "application/json" {
+		t.Errorf("Expected content type application/json, got %s", formatter.ContentType())
+	}
+}
+
+func TestXMLFormatter(t *testing.T) {
+	formatter := NewXMLFormatter()
+	
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	record.Time = time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	record.Attributes.SetFast("key", "value")
+
+	data, err := formatter.Format(record)
+	if err != nil {
+		t.Fatalf("XMLFormatter.Format failed: %v", err)
+	}
+
+	output := string(data)
+	if !strings.Contains(output, "<record>") {
+		t.Errorf("Expected XML record tag: %s", output)
+	}
+	if !strings.Contains(output, "<message>Test message</message>") {
+		t.Errorf("Expected message in XML output: %s", output)
+	}
+	if !strings.Contains(output, "<level>INFO</level>") {
+		t.Errorf("Expected level in XML output: %s", output)
+	}
+	if !strings.Contains(output, "key=value") {
+		t.Errorf("Expected attributes in XML output: %s", output)
+	}
+}
+
+func TestXMLFormatterContentType(t *testing.T) {
+	formatter := NewXMLFormatter()
+	if formatter.ContentType() != "application/xml" {
+		t.Errorf("Expected content type application/xml, got %s", formatter.ContentType())
+	}
+}
+
+func TestYAMLFormatter(t *testing.T) {
+	formatter := NewYAMLFormatter()
+	
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	record.Time = time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	record.Attributes.SetFast("key", "value")
+
+	data, err := formatter.Format(record)
+	if err != nil {
+		t.Fatalf("YAMLFormatter.Format failed: %v", err)
+	}
+
+	output := string(data)
+	if !strings.Contains(output, `message: "Test message"`) {
+		t.Errorf("Expected message in YAML output: %s", output)
+	}
+	if !strings.Contains(output, "level: INFO") {
+		t.Errorf("Expected level in YAML output: %s", output)
+	}
+	if !strings.Contains(output, "key: value") {
+		t.Errorf("Expected attributes in YAML output: %s", output)
+	}
+}
+
+func TestYAMLFormatterContentType(t *testing.T) {
+	formatter := NewYAMLFormatter()
+	if formatter.ContentType() != "application/x-yaml" {
+		t.Errorf("Expected content type application/x-yaml, got %s", formatter.ContentType())
+	}
+}
+
+func TestTextFormatter(t *testing.T) {
+	formatter := NewTextFormatter()
+	
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	record.Time = time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	record.Attributes.SetFast("key", "value")
+
+	data, err := formatter.Format(record)
+	if err != nil {
+		t.Fatalf("TextFormatter.Format failed: %v", err)
+	}
+
+	output := string(data)
+	if !strings.Contains(output, "Test message") {
+		t.Errorf("Expected message in text output: %s", output)
+	}
+	if !strings.Contains(output, "[INFO]") {
+		t.Errorf("Expected level in text output: %s", output)
+	}
+	if !strings.Contains(output, "key: value") {
+		t.Errorf("Expected attributes in text output: %s", output)
+	}
+}
+
+func TestTextFormatterMarkLevel(t *testing.T) {
+	formatter := NewTextFormatter()
+	
+	record := NewRecordFromPool(LevelMark, "Test mark")
+	record.Time = time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	data, err := formatter.Format(record)
+	if err != nil {
+		t.Fatalf("TextFormatter.Format mark failed: %v", err)
+	}
+
+	output := string(data)
+	if !strings.Contains(output, "MARK") || !strings.Contains(output, "=") {
+		t.Errorf("Expected mark formatting in output: %s", output)
+	}
+}
+
+func TestTextFormatterWithColors(t *testing.T) {
+	colorMappings := map[string]string{
+		"user": "\033[32m", // green
+	}
+	formatter := NewTextFormatterWithColors(colorMappings)
+	formatter.ColorOutput = true
+	
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	record.Attributes.SetFast("user", "john")
+
+	data, err := formatter.Format(record)
+	if err != nil {
+		t.Fatalf("TextFormatter.Format with colors failed: %v", err)
+	}
+
+	output := string(data)
+	// Should contain ANSI color codes
+	if !strings.Contains(output, "\033[") {
+		t.Errorf("Expected colored output: %s", output)
+	}
+}
+
+func TestTextFormatterFlatAttributes(t *testing.T) {
+	formatter := NewTextFormatter()
+	formatter.AttributeFormat = "flat"
+	
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	record.Attributes.SetFast("key1", "value1")
+	record.Attributes.SetFast("key2", "value2")
+
+	data, err := formatter.Format(record)
+	if err != nil {
+		t.Fatalf("TextFormatter.Format with flat attributes failed: %v", err)
+	}
+
+	output := string(data)
+	if !strings.Contains(output, "key1=value1") || !strings.Contains(output, "key2=value2") {
+		t.Errorf("Expected flat attributes in output: %s", output)
+	}
+}
+
+func TestTextFormatterContentType(t *testing.T) {
+	formatter := NewTextFormatter()
+	if formatter.ContentType() != "text/plain" {
+		t.Errorf("Expected content type text/plain, got %s", formatter.ContentType())
+	}
+}
+
+func TestKeyValueFormatter(t *testing.T) {
+	formatter := NewKeyValueFormatter()
+	
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	record.Time = time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	record.Attributes.SetFast("key", "value")
+
+	data, err := formatter.Format(record)
+	if err != nil {
+		t.Fatalf("KeyValueFormatter.Format failed: %v", err)
+	}
+
+	output := string(data)
+	if !strings.Contains(output, "message=Test message") {
+		t.Errorf("Expected message in key-value output: %s", output)
+	}
+	if !strings.Contains(output, "level=INFO") {
+		t.Errorf("Expected level in key-value output: %s", output)
+	}
+	if !strings.Contains(output, "key=value") {
+		t.Errorf("Expected attributes in key-value output: %s", output)
+	}
+}
+
+func TestKeyValueFormatterMarkLevel(t *testing.T) {
+	formatter := NewKeyValueFormatter()
+	
+	record := NewRecordFromPool(LevelMark, "Test mark")
+	record.Time = time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	data, err := formatter.Format(record)
+	if err != nil {
+		t.Fatalf("KeyValueFormatter.Format mark failed: %v", err)
+	}
+
+	output := string(data)
+	if !strings.Contains(output, "MARK") || !strings.Contains(output, "=") {
+		t.Errorf("Expected mark formatting in output: %s", output)
+	}
+}
+
+func TestKeyValueFormatterWithColors(t *testing.T) {
+	colorMappings := map[string]string{
+		"user": "\033[32m", // green
+	}
+	formatter := NewKeyValueFormatterWithColors(colorMappings)
+	formatter.ColorOutput = true
+	
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	record.Attributes.SetFast("user", "john")
+
+	data, err := formatter.Format(record)
+	if err != nil {
+		t.Fatalf("KeyValueFormatter.Format with colors failed: %v", err)
+	}
+
+	output := string(data)
+	// Should contain ANSI color codes
+	if !strings.Contains(output, "\033[") {
+		t.Errorf("Expected colored output: %s", output)
+	}
+}
+
+func TestKeyValueFormatterStructExpansion(t *testing.T) {
+	formatter := NewKeyValueFormatter()
+	
+	type User struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+	
+	record := NewRecordFromPool(LevelInfo, "User info")
+	user := User{ID: 123, Name: "John"}
+	record.Attributes.ExpandStruct("user", user)
+
+	data, err := formatter.Format(record)
+	if err != nil {
+		t.Fatalf("KeyValueFormatter.Format with struct failed: %v", err)
+	}
+
+	output := string(data)
+	if !strings.Contains(output, "user.id=123") || !strings.Contains(output, "user.name=John") {
+		t.Errorf("Expected expanded struct attributes: %s", output)
+	}
+}
+
+func TestKeyValueFormatterContentType(t *testing.T) {
+	formatter := NewKeyValueFormatter()
+	if formatter.ContentType() != "text/plain" {
+		t.Errorf("Expected content type text/plain, got %s", formatter.ContentType())
+	}
+}
+
+func TestLevelToString(t *testing.T) {
+	tests := []struct {
+		level    Level
+		expected string
+	}{
+		{LevelTrace, "TRACE"},
+		{LevelDebug, "DEBUG"},
+		{LevelInfo, "INFO"},
+		{LevelWarn, "WARN"},
+		{LevelError, "ERROR"},
+		{LevelFatal, "FATAL"},
+		{LevelPanic, "PANIC"},
+		{LevelMark, "MARK"},
+		{Level(999), "UNKNOWN"},
+	}
+
+	for _, test := range tests {
+		result := levelToString(test.level)
+		if result != test.expected {
+			t.Errorf("levelToString(%v) = %s, want %s", test.level, result, test.expected)
+		}
+	}
+}
+
+func TestJSONFormatterOptimizedFunctions(t *testing.T) {
+	formatter := NewJSONFormatter()
+	
+	// Test writeJSONEscapedString
+	record := NewRecordFromPool(LevelInfo, "Test with \"quotes\" and \n newlines")
+	data, err := formatter.Format(record)
+	if err != nil {
+		t.Fatalf("Format with special characters failed: %v", err)
+	}
+	
+	output := string(data)
+	if !strings.Contains(output, `\"quotes\"`) {
+		t.Errorf("Expected escaped quotes in output: %s", output)
+	}
+	if !strings.Contains(output, `\n`) {
+		t.Errorf("Expected escaped newline in output: %s", output)
+	}
+}
+
+func TestFormatterWithCustomKeys(t *testing.T) {
+	// Test JSON formatter with custom key
+	jsonFormatter := NewJSONFormatterWithKey("data")
+	record := NewRecordFromPool(LevelInfo, "Test")
+	record.Attributes.SetFast("key", "value")
+	
+	data, err := jsonFormatter.Format(record)
+	if err != nil {
+		t.Fatalf("JSON format with custom key failed: %v", err)
+	}
+	if !strings.Contains(string(data), `"data":`) {
+		t.Errorf("Expected custom attributes key in JSON output: %s", string(data))
+	}
+
+	// Test XML formatter with custom key
+	xmlFormatter := NewXMLFormatterWithKey("data")
+	data, err = xmlFormatter.Format(record)
+	if err != nil {
+		t.Fatalf("XML format with custom key failed: %v", err)
+	}
+	
+	// Test YAML formatter with custom key
+	yamlFormatter := NewYAMLFormatterWithKey("data")
+	data, err = yamlFormatter.Format(record)
+	if err != nil {
+		t.Fatalf("YAML format with custom key failed: %v", err)
+	}
+	if !strings.Contains(string(data), "data:") {
+		t.Errorf("Expected custom attributes key in YAML output: %s", string(data))
+	}
+}
+
+func TestFormatterIncludeSource(t *testing.T) {
+	tests := []struct {
+		name      string
+		formatter Formatter
+	}{
+		{"JSON", NewJSONFormatter()},
+		{"XML", NewXMLFormatter()},
+		{"YAML", NewYAMLFormatter()},
+		{"Text", NewTextFormatter()},
+		{"KeyValue", NewKeyValueFormatter()},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Set include source to true
+			switch f := test.formatter.(type) {
+			case *JSONFormatter:
+				f.IncludeSource = true
+			case *XMLFormatter:
+				f.IncludeSource = true
+			case *YAMLFormatter:
+				f.IncludeSource = true
+			case *TextFormatter:
+				f.IncludeSource = true
+			case *KeyValueFormatter:
+				f.IncludeSource = true
+			}
+
+			record := NewRecordFromPool(LevelInfo, "Test message")
+			record.PC = 1 // Set a non-zero PC to trigger source capture
+			
+			data, err := test.formatter.Format(record)
+			if err != nil {
+				t.Fatalf("%s formatter with source failed: %v", test.name, err)
+			}
+
+			// Just verify it doesn't crash - source info may or may not be included
+			// depending on whether we can resolve the PC
+			if len(data) == 0 {
+				t.Errorf("%s formatter produced empty output", test.name)
+			}
+		})
+	}
+}
+
+func TestFormatterIncludeLevel(t *testing.T) {
+	tests := []struct {
+		name      string
+		formatter Formatter
+	}{
+		{"JSON", NewJSONFormatter()},
+		{"XML", NewXMLFormatter()},
+		{"YAML", NewYAMLFormatter()},
+		{"Text", NewTextFormatter()},
+		{"KeyValue", NewKeyValueFormatter()},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name+" with level", func(t *testing.T) {
+			// Ensure include level is true (default for most)
+			switch f := test.formatter.(type) {
+			case *JSONFormatter:
+				f.IncludeLevel = true
+			case *XMLFormatter:
+				f.IncludeLevel = true
+			case *YAMLFormatter:
+				f.IncludeLevel = true
+			case *TextFormatter:
+				f.IncludeLevel = true
+			case *KeyValueFormatter:
+				f.IncludeLevel = true
+			}
+
+			record := NewRecordFromPool(LevelError, "Test error")
+			data, err := test.formatter.Format(record)
+			if err != nil {
+				t.Fatalf("%s formatter with level failed: %v", test.name, err)
+			}
+
+			output := string(data)
+			if !strings.Contains(output, "ERROR") {
+				t.Errorf("%s formatter should include ERROR level: %s", test.name, output)
+			}
+		})
+
+		t.Run(test.name+" without level", func(t *testing.T) {
+			// Set include level to false
+			switch f := test.formatter.(type) {
+			case *JSONFormatter:
+				f.IncludeLevel = false
+			case *XMLFormatter:
+				f.IncludeLevel = false
+			case *YAMLFormatter:
+				f.IncludeLevel = false
+			case *TextFormatter:
+				f.IncludeLevel = false
+			case *KeyValueFormatter:
+				f.IncludeLevel = false
+			}
+
+			record := NewRecordFromPool(LevelError, "Test error")
+			data, err := test.formatter.Format(record)
+			if err != nil {
+				t.Fatalf("%s formatter without level failed: %v", test.name, err)
+			}
+
+			// Output should still be valid
+			if len(data) == 0 {
+				t.Errorf("%s formatter produced empty output", test.name)
+			}
+		})
+	}
+}

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -1,0 +1,525 @@
+package sawmill
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTextHandler(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewTextHandler(WithDestination(NewWriterDestination(buf)))
+
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	record.Time = time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	record.Attributes.SetFast("key", "value")
+
+	err := handler.Handle(context.Background(), record)
+	if err != nil {
+		t.Fatalf("Handle failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "Test message") {
+		t.Errorf("Expected message in output: %s", output)
+	}
+	if !strings.Contains(output, "key: value") {
+		t.Errorf("Expected attributes in output: %s", output)
+	}
+}
+
+func TestJSONHandler(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewJSONHandler(WithDestination(NewWriterDestination(buf)))
+
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	record.Time = time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	record.Attributes.SetFast("key", "value")
+
+	err := handler.Handle(context.Background(), record)
+	if err != nil {
+		t.Fatalf("Handle failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, `"message":"Test message"`) {
+		t.Errorf("Expected JSON message in output: %s", output)
+	}
+	if !strings.Contains(output, `"key":"value"`) {
+		t.Errorf("Expected JSON attributes in output: %s", output)
+	}
+}
+
+func TestXMLHandler(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewXMLHandler(WithDestination(NewWriterDestination(buf)))
+
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	record.Time = time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	record.Attributes.SetFast("key", "value")
+
+	err := handler.Handle(context.Background(), record)
+	if err != nil {
+		t.Fatalf("Handle failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "<record>") {
+		t.Errorf("Expected XML record tag in output: %s", output)
+	}
+	if !strings.Contains(output, "<message>Test message</message>") {
+		t.Errorf("Expected XML message in output: %s", output)
+	}
+}
+
+func TestYAMLHandler(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewYAMLHandler(WithDestination(NewWriterDestination(buf)))
+
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	record.Time = time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	record.Attributes.SetFast("key", "value")
+
+	err := handler.Handle(context.Background(), record)
+	if err != nil {
+		t.Fatalf("Handle failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, `message: "Test message"`) {
+		t.Errorf("Expected YAML message in output: %s", output)
+	}
+	if !strings.Contains(output, "key: value") {
+		t.Errorf("Expected YAML attributes in output: %s", output)
+	}
+}
+
+func TestKeyValueHandler(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewKeyValueHandler(WithDestination(NewWriterDestination(buf)))
+
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	record.Time = time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	record.Attributes.SetFast("key", "value")
+
+	err := handler.Handle(context.Background(), record)
+	if err != nil {
+		t.Fatalf("Handle failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "message=Test message") {
+		t.Errorf("Expected key-value message in output: %s", output)
+	}
+	if !strings.Contains(output, "key=value") {
+		t.Errorf("Expected key-value attributes in output: %s", output)
+	}
+}
+
+func TestMultiHandler(t *testing.T) {
+	buf1 := &bytes.Buffer{}
+	buf2 := &bytes.Buffer{}
+	
+	handler1 := NewTextHandler(WithDestination(NewWriterDestination(buf1)))
+	handler2 := NewJSONHandler(WithDestination(NewWriterDestination(buf2)))
+	multiHandler := NewMultiHandler(handler1, handler2)
+
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	record.Time = time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+
+	err := multiHandler.Handle(context.Background(), record)
+	if err != nil {
+		t.Fatalf("MultiHandler Handle failed: %v", err)
+	}
+
+	output1 := buf1.String()
+	output2 := buf2.String()
+
+	if !strings.Contains(output1, "Test message") {
+		t.Errorf("Expected text output in first handler: %s", output1)
+	}
+	if !strings.Contains(output2, `"message":"Test message"`) {
+		t.Errorf("Expected JSON output in second handler: %s", output2)
+	}
+}
+
+func TestHandlerEnabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		handlerLevel Level
+		logLevel     Level
+		expected     bool
+	}{
+		{"Info handler with Info log", LevelInfo, LevelInfo, true},
+		{"Info handler with Debug log", LevelInfo, LevelDebug, false},
+		{"Info handler with Error log", LevelInfo, LevelError, true},
+		{"Error handler with Info log", LevelError, LevelInfo, false},
+		{"Debug handler with Trace log", LevelDebug, LevelTrace, false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler := NewTextHandler(WithLevel(test.handlerLevel))
+			enabled := handler.Enabled(context.Background(), test.logLevel)
+			if enabled != test.expected {
+				t.Errorf("Expected enabled=%v for handler level %v and log level %v", 
+					test.expected, test.handlerLevel, test.logLevel)
+			}
+		})
+	}
+}
+
+func TestHandlerWithAttrs(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewJSONHandler(WithDestination(NewWriterDestination(buf)))
+
+	attrs := []slog.Attr{
+		slog.String("service", "api"),
+		slog.Int("version", 1),
+	}
+
+	newHandler := handler.WithAttrs(attrs)
+	record := NewRecordFromPool(LevelInfo, "Test message")
+
+	err := newHandler.Handle(context.Background(), record)
+	if err != nil {
+		t.Fatalf("Handle with attrs failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, `"service":"api"`) {
+		t.Errorf("Expected service attribute in output: %s", output)
+	}
+	if !strings.Contains(output, `"version":1`) {
+		t.Errorf("Expected version attribute in output: %s", output)
+	}
+}
+
+func TestHandlerWithGroup(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewJSONHandler(WithDestination(NewWriterDestination(buf)))
+
+	// Add attributes via handler with group - this is how groups work
+	attrs := []slog.Attr{slog.String("method", "GET")}
+	groupHandler := handler.WithGroup("request").WithAttrs(attrs)
+	record := NewRecordFromPool(LevelInfo, "Test message")
+
+	err := groupHandler.Handle(context.Background(), record)
+	if err != nil {
+		t.Fatalf("Handle with group failed: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, `"request.method":"GET"`) {
+		t.Errorf("Expected grouped attribute in output: %s", output)
+	}
+}
+
+func TestMultiHandlerWithAttrs(t *testing.T) {
+	buf1 := &bytes.Buffer{}
+	buf2 := &bytes.Buffer{}
+	
+	handler1 := NewTextHandler(WithDestination(NewWriterDestination(buf1)))
+	handler2 := NewJSONHandler(WithDestination(NewWriterDestination(buf2)))
+	multiHandler := NewMultiHandler(handler1, handler2)
+
+	attrs := []slog.Attr{slog.String("service", "test")}
+	newMultiHandler := multiHandler.WithAttrs(attrs)
+
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	err := newMultiHandler.Handle(context.Background(), record)
+	if err != nil {
+		t.Fatalf("MultiHandler WithAttrs Handle failed: %v", err)
+	}
+
+	output1 := buf1.String()
+	output2 := buf2.String()
+
+	if !strings.Contains(output1, "service: test") {
+		t.Errorf("Expected service attribute in text output: %s", output1)
+	}
+	if !strings.Contains(output2, `"service":"test"`) {
+		t.Errorf("Expected service attribute in JSON output: %s", output2)
+	}
+}
+
+func TestMultiHandlerWithGroup(t *testing.T) {
+	buf1 := &bytes.Buffer{}
+	buf2 := &bytes.Buffer{}
+	
+	handler1 := NewTextHandler(WithDestination(NewWriterDestination(buf1)))
+	handler2 := NewJSONHandler(WithDestination(NewWriterDestination(buf2)))
+	multiHandler := NewMultiHandler(handler1, handler2)
+
+	// Add attributes via handler with group
+	attrs := []slog.Attr{slog.String("key", "value")}
+	groupHandler := multiHandler.WithGroup("test").WithAttrs(attrs)
+	record := NewRecordFromPool(LevelInfo, "Test message")
+
+	err := groupHandler.Handle(context.Background(), record)
+	if err != nil {
+		t.Fatalf("MultiHandler WithGroup Handle failed: %v", err)
+	}
+
+	output1 := buf1.String()
+	output2 := buf2.String()
+
+	if !strings.Contains(output1, "test:") || !strings.Contains(output1, "key: value") {
+		t.Errorf("Expected grouped attribute in text output: %s", output1)
+	}
+	if !strings.Contains(output2, `"test.key":"value"`) {
+		t.Errorf("Expected grouped attribute in JSON output: %s", output2)
+	}
+}
+
+func TestMultiHandlerEnabled(t *testing.T) {
+	handler1 := NewTextHandler(WithLevel(LevelError))
+	handler2 := NewJSONHandler(WithLevel(LevelInfo))
+	multiHandler := NewMultiHandler(handler1, handler2)
+
+	// Should be enabled if any handler is enabled
+	if !multiHandler.Enabled(context.Background(), LevelInfo) {
+		t.Error("MultiHandler should be enabled if any sub-handler is enabled")
+	}
+
+	// Should be disabled if no handlers are enabled
+	if multiHandler.Enabled(context.Background(), LevelTrace) {
+		t.Error("MultiHandler should be disabled if no sub-handlers are enabled")
+	}
+}
+
+func TestHandlerWithDefaultOptions(t *testing.T) {
+	handlers := []Handler{
+		NewTextHandlerWithDefaults(),
+		NewJSONHandlerWithDefaults(),
+		NewXMLHandlerWithDefaults(),
+		NewYAMLHandlerWithDefaults(),
+		NewKeyValueHandlerWithDefaults(),
+	}
+
+	for i, handler := range handlers {
+		t.Run(string(rune('A'+i)), func(t *testing.T) {
+			if handler == nil {
+				t.Fatal("Handler with defaults returned nil")
+			}
+			
+			record := NewRecordFromPool(LevelInfo, "Test message")
+			err := handler.Handle(context.Background(), record)
+			if err != nil {
+				t.Fatalf("Handle with defaults failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestDeprecatedHandlerFunctions(t *testing.T) {
+	dest := NewWriterDestination(os.Stdout)
+	opts := &SawmillOptions{}
+
+	// Test deprecated functions don't panic
+	jsonHandler := NewJSONHandlerWithKey(dest, opts, "custom")
+	if jsonHandler == nil {
+		t.Error("NewJSONHandlerWithKey returned nil")
+	}
+
+	xmlHandler := NewXMLHandlerWithKey(dest, opts, "custom")
+	if xmlHandler == nil {
+		t.Error("NewXMLHandlerWithKey returned nil")
+	}
+
+	yamlHandler := NewYAMLHandlerWithKey(dest, opts, "custom")
+	if yamlHandler == nil {
+		t.Error("NewYAMLHandlerWithKey returned nil")
+	}
+
+	textHandler := NewTextHandlerWithColors(dest, opts, map[string]string{"key": "red"}, true)
+	if textHandler == nil {
+		t.Error("NewTextHandlerWithColors returned nil")
+	}
+
+	jsonHandlerColors := NewJSONHandlerWithColors(dest, opts, map[string]string{"key": "blue"}, true)
+	if jsonHandlerColors == nil {
+		t.Error("NewJSONHandlerWithColors returned nil")
+	}
+}
+
+func TestBaseHandlerNeedsSource(t *testing.T) {
+	tests := []struct {
+		name     string
+		handler  Handler
+		expected bool
+	}{
+		{
+			name:     "Text handler with source",
+			handler:  NewTextHandler(WithSourceInfo(true)),
+			expected: true,
+		},
+		{
+			name:     "Text handler without source",
+			handler:  NewTextHandler(WithSourceInfo(false)),
+			expected: false,
+		},
+		{
+			name:     "JSON handler with source",
+			handler:  NewJSONHandler(WithSourceInfo(true)),
+			expected: true,
+		},
+		{
+			name:     "JSON handler without source",
+			handler:  NewJSONHandler(WithSourceInfo(false)),
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if baseHandler, ok := test.handler.(*TextHandler); ok {
+				if got := baseHandler.BaseHandler.NeedsSource(); got != test.expected {
+					t.Errorf("NeedsSource() = %v, want %v", got, test.expected)
+				}
+			} else if baseHandler, ok := test.handler.(*JSONHandler); ok {
+				if got := baseHandler.BaseHandler.NeedsSource(); got != test.expected {
+					t.Errorf("NeedsSource() = %v, want %v", got, test.expected)
+				}
+			}
+		})
+	}
+}
+
+func TestGetDestinationBuffer(t *testing.T) {
+	// Test with nil destination
+	buffer := getDestinationBuffer(nil)
+	if buffer == nil {
+		t.Error("getDestinationBuffer with nil should return default buffer")
+	}
+
+	// Test with writer destination
+	buf := &bytes.Buffer{}
+	writerDest := NewWriterDestination(buf)
+	buffer = getDestinationBuffer(writerDest)
+	if buffer == nil {
+		t.Error("getDestinationBuffer with WriterDestination should return buffer")
+	}
+
+	// Test with file destination
+	fileDest := NewFileDestination("test.log", 1024, 86400, false)
+	buffer = getDestinationBuffer(fileDest)
+	if buffer == nil {
+		t.Error("getDestinationBuffer with FileDestination should return buffer")
+	}
+}
+
+func TestParseLevel(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected Level
+	}{
+		{"trace", LevelTrace},
+		{"debug", LevelDebug},
+		{"info", LevelInfo},
+		{"warn", LevelWarn},
+		{"error", LevelError},
+		{"fatal", LevelFatal},
+		{"panic", LevelPanic},
+		{"mark", LevelMark},
+		{"invalid", LevelInfo}, // default
+		{"", LevelInfo},        // default
+	}
+
+	for _, test := range tests {
+		result := parseLevel(test.input)
+		if result != test.expected {
+			t.Errorf("parseLevel(%q) = %v, want %v", test.input, result, test.expected)
+		}
+	}
+}
+
+func TestDestinationMethods(t *testing.T) {
+	// Test WriterDestination
+	buf := &bytes.Buffer{}
+	writerDest := NewWriterDestination(buf)
+	
+	n, err := writerDest.Write([]byte("test"))
+	if err != nil {
+		t.Errorf("WriterDestination.Write failed: %v", err)
+	}
+	if n != 4 {
+		t.Errorf("WriterDestination.Write returned %d, want 4", n)
+	}
+	
+	err = writerDest.Close()
+	if err != nil {
+		t.Errorf("WriterDestination.Close failed: %v", err)
+	}
+
+	// Test FileDestination methods
+	fileDest := NewFileDestination("test.log", 1024, 86400, false)
+	
+	_, err = fileDest.Write([]byte("test"))
+	if err == nil {
+		t.Error("FileDestination.Write should return error - not implemented")
+	}
+	
+	err = fileDest.Close()
+	if err != nil {
+		t.Errorf("FileDestination.Close failed: %v", err)
+	}
+
+	// Test NetworkDestination methods
+	networkDest := &NetworkDestination{}
+	
+	_, err = networkDest.Write([]byte("test"))
+	if err == nil {
+		t.Error("NetworkDestination.Write should return error - not implemented")
+	}
+	
+	err = networkDest.Close()
+	if err != nil {
+		t.Errorf("NetworkDestination.Close failed: %v", err)
+	}
+}
+
+func TestTemporaryHandler(t *testing.T) {
+	buf := &bytes.Buffer{}
+	originalHandler := NewTextHandler(WithDestination(NewWriterDestination(buf)))
+	formatter := NewJSONFormatter()
+	
+	tempHandler := &temporaryHandler{
+		originalHandler: originalHandler,
+		formatter:       formatter,
+	}
+
+	record := NewRecordFromPool(LevelInfo, "Test message")
+	err := tempHandler.Handle(context.Background(), record)
+	if err != nil {
+		t.Fatalf("temporaryHandler.Handle failed: %v", err)
+	}
+
+	output := buf.String()
+	// Should be JSON formatted even though original handler is text
+	if !strings.Contains(output, `"message":"Test message"`) {
+		t.Errorf("Expected JSON output from temporary handler: %s", output)
+	}
+
+	// Test WithAttrs
+	attrs := []slog.Attr{slog.String("key", "value")}
+	newTempHandler := tempHandler.WithAttrs(attrs)
+	if newTempHandler == nil {
+		t.Error("temporaryHandler.WithAttrs returned nil")
+	}
+
+	// Test WithGroup
+	groupHandler := tempHandler.WithGroup("test")
+	if groupHandler == nil {
+		t.Error("temporaryHandler.WithGroup returned nil")
+	}
+
+	// Test Enabled
+	if !tempHandler.Enabled(context.Background(), LevelInfo) {
+		t.Error("temporaryHandler should be enabled for info level")
+	}
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,311 @@
+package sawmill
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+func TestNewLogger(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewTextHandler(WithDestination(NewWriterDestination(buf)))
+	logger := New(handler)
+
+	if logger == nil {
+		t.Fatal("New() returned nil logger")
+	}
+
+	logger.Info("Test message")
+	output := buf.String()
+	if !strings.Contains(output, "Test message") {
+		t.Errorf("Expected output to contain test message: %s", output)
+	}
+}
+
+func TestDefaultLogger(t *testing.T) {
+	logger := Default()
+	if logger == nil {
+		t.Fatal("Default() returned nil logger")
+	}
+}
+
+func TestLoggerLevels(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := New(NewTextHandler(WithDestination(NewWriterDestination(buf)), WithLevel(LevelTrace)))
+
+	tests := []struct {
+		level    string
+		logFunc  func(string, ...interface{})
+		expected string
+	}{
+		{"TRACE", logger.Trace, "TRACE"},
+		{"DEBUG", logger.Debug, "DEBUG"},
+		{"INFO", logger.Info, "INFO"},
+		{"WARN", logger.Warn, "WARN"},
+		{"ERROR", logger.Error, "ERROR"},
+		{"FATAL", logger.Fatal, "FATAL"},
+		{"MARK", logger.Mark, "MARK"},
+	}
+
+	for _, test := range tests {
+		buf.Reset()
+		test.logFunc("Test "+test.level+" message")
+		output := buf.String()
+		
+		if !strings.Contains(output, test.expected) {
+			t.Errorf("Expected %s level output to contain '%s': %s", test.level, test.expected, output)
+		}
+		// MARK level has special formatting, so only check message for other levels
+		if test.level != "MARK" && !strings.Contains(output, "Test "+test.level+" message") {
+			t.Errorf("Expected output to contain message: %s", output)
+		}
+		// For MARK level, just check that it contains MARKED (special format)
+		if test.level == "MARK" && !strings.Contains(output, "MARKED") {
+			t.Errorf("Expected MARK output to contain MARKED: %s", output)
+		}
+	}
+}
+
+func TestLoggerPanic(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := New(NewTextHandler(WithDestination(NewWriterDestination(buf))))
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Expected Panic to panic")
+		}
+	}()
+
+	logger.Panic("Test panic message")
+}
+
+func TestLoggerWithNested(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := New(NewJSONHandler(WithDestination(NewWriterDestination(buf))))
+
+	nestedLogger := logger.WithNested([]string{"user", "profile"}, "john")
+	nestedLogger.Info("User info")
+
+	output := buf.String()
+	if !strings.Contains(output, "\"user.profile\":\"john\"") {
+		t.Errorf("Expected nested attribute in output: %s", output)
+	}
+}
+
+func TestLoggerWithDot(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := New(NewJSONHandler(WithDestination(NewWriterDestination(buf))))
+
+	dotLogger := logger.WithDot("user.email", "john@example.com")
+	dotLogger.Info("User info")
+
+	output := buf.String()
+	if !strings.Contains(output, "\"user.email\":\"john@example.com\"") {
+		t.Errorf("Expected dot notation attribute in output: %s", output)
+	}
+}
+
+func TestLoggerWithGroup(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := New(NewJSONHandler(WithDestination(NewWriterDestination(buf))))
+
+	groupLogger := logger.WithGroup("request")
+	groupLogger.Info("Request processed", "method", "GET", "path", "/api/users")
+
+	output := buf.String()
+	if !strings.Contains(output, "\"request.method\":\"GET\"") || !strings.Contains(output, "\"request.path\":\"/api/users\"") {
+		t.Errorf("Expected grouped attributes in output: %s", output)
+	}
+}
+
+func TestLoggerWithCallback(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := New(NewTextHandler(WithDestination(NewWriterDestination(buf))))
+
+	callbackLogger := logger.WithCallback(func(record *Record) *Record {
+		record.Message = "[MODIFIED] " + record.Message
+		return record
+	})
+
+	callbackLogger.Info("Original message")
+	output := buf.String()
+
+	if !strings.Contains(output, "[MODIFIED] Original message") {
+		t.Errorf("Expected callback to modify message: %s", output)
+	}
+}
+
+func TestLoggerSetHandler(t *testing.T) {
+	buf1 := &bytes.Buffer{}
+	buf2 := &bytes.Buffer{}
+	
+	handler1 := NewTextHandler(WithDestination(NewWriterDestination(buf1)))
+	handler2 := NewJSONHandler(WithDestination(NewWriterDestination(buf2)))
+
+	logger := New(handler1)
+	logger.Info("Text message")
+
+	if buf1.Len() == 0 {
+		t.Error("Expected text handler to write output")
+	}
+
+	logger.SetHandler(handler2)
+	logger.Info("JSON message")
+
+	if buf2.Len() == 0 {
+		t.Error("Expected JSON handler to write output after SetHandler")
+	}
+}
+
+func TestLoggerHandler(t *testing.T) {
+	handler := NewTextHandler()
+	logger := New(handler)
+
+	if logger.Handler() != handler {
+		t.Error("Handler() should return the same handler that was set")
+	}
+}
+
+func TestLoggerWithAttrs(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewJSONHandler(WithDestination(NewWriterDestination(buf)))
+
+	attrs := []slog.Attr{
+		slog.String("service", "api"),
+		slog.Int("port", 8080),
+	}
+
+	attrHandler := handler.WithAttrs(attrs)
+	logger := New(attrHandler)
+	logger.Info("Service started")
+
+	output := buf.String()
+	if !strings.Contains(output, "\"service\":\"api\"") || !strings.Contains(output, "\"port\":8080") {
+		t.Errorf("Expected slog attributes in output: %s", output)
+	}
+}
+
+func TestLoggerLogRecord(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := New(NewTextHandler(WithDestination(NewWriterDestination(buf))))
+
+	record := NewRecordFromPool(LevelInfo, "Test record message")
+	record.Attributes.SetFast("key", "value")
+
+	logger.LogRecord(context.Background(), record)
+	
+	output := buf.String()
+	if !strings.Contains(output, "Test record message") {
+		t.Errorf("Expected record message in output: %s", output)
+	}
+	if !strings.Contains(output, "key: value") {
+		t.Errorf("Expected record attributes in output: %s", output)
+	}
+}
+
+func TestLoggerStructExpansion(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := New(NewJSONHandler(WithDestination(NewWriterDestination(buf))))
+
+	type User struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+
+	user := User{ID: 123, Name: "John Doe"}
+	logger.Info("User created", "user", user)
+
+	output := buf.String()
+	if !strings.Contains(output, "\"user.id\":123") || !strings.Contains(output, "\"user.name\":\"John Doe\"") {
+		t.Errorf("Expected struct expansion in output: %s", output)
+	}
+}
+
+func TestLoggerHTTPErrorLog(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := New(NewTextHandler(WithDestination(NewWriterDestination(buf))))
+
+	httpLogger := logger.HTTPErrorLog()
+	if httpLogger == nil {
+		t.Fatal("HTTPErrorLog() returned nil")
+	}
+
+	httpLogger.Println("HTTP error message")
+	output := buf.String()
+
+	if !strings.Contains(output, "HTTP error message") {
+		t.Errorf("Expected HTTP error message in output: %s", output)
+	}
+	if !strings.Contains(output, "ERROR") {
+		t.Errorf("Expected ERROR level in output: %s", output)
+	}
+}
+
+func TestNeedsSourceCapture(t *testing.T) {
+	tests := []struct {
+		name     string
+		handler  Handler
+		expected bool
+	}{
+		{
+			name:     "TextHandler with source enabled",
+			handler:  NewTextHandler(WithSourceInfo(true)),
+			expected: true,
+		},
+		{
+			name:     "TextHandler with source disabled", 
+			handler:  NewTextHandler(WithSourceInfo(false)),
+			expected: false,
+		},
+		{
+			name:     "JSONHandler with source enabled",
+			handler:  NewJSONHandler(WithSourceInfo(true)),
+			expected: true,
+		},
+		{
+			name:     "JSONHandler with source disabled",
+			handler:  NewJSONHandler(WithSourceInfo(false)),
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger := New(test.handler).(*logger)
+			if got := logger.needsSourceCapture(); got != test.expected {
+				t.Errorf("needsSourceCapture() = %v, want %v", got, test.expected)
+			}
+		})
+	}
+}
+
+func TestGlobalLoggerFunctions(t *testing.T) {
+	// Test that global functions work without panicking
+	Trace("Test trace")
+	Debug("Test debug")  
+	Info("Test info")
+	Warn("Test warn")
+	Error("Test error")
+	Mark("Test mark")
+
+	// Test global With functions
+	WithNested([]string{"test"}, "value").Info("Nested test")
+	WithDot("test.dot", "value").Info("Dot test")
+	WithGroup("testgroup").Info("Group test")
+	WithCallback(func(r *Record) *Record { return r }).Info("Callback test")
+}
+
+func TestSetDefaultHandler(t *testing.T) {
+	buf := &bytes.Buffer{}
+	handler := NewTextHandler(WithDestination(NewWriterDestination(buf)))
+	
+	SetDefaultHandler(handler)
+	Info("Test message with new handler")
+	
+	output := buf.String()
+	if !strings.Contains(output, "Test message with new handler") {
+		t.Errorf("Expected message in output after SetDefaultHandler: %s", output)
+	}
+}

--- a/masking_test.go
+++ b/masking_test.go
@@ -1,0 +1,221 @@
+package sawmill
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// Test structs for masking functionality
+type UserCredentials struct {
+	Username string `sawmill:""`
+	Password string `sawmill:"mask"`
+	Email    string `sawmill:"mask[4]"`
+	APIKey   string `sawmill:"mask[8]"`
+	Token    string `sawmill:"mask[0]"`
+	ID       int    `sawmill:"mask[2]"`
+}
+
+type NestedUser struct {
+	Name        string
+	Credentials UserCredentials
+	SessionID   string `sawmill:"mask"`
+}
+
+func TestStructMasking(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := New(NewJSONHandler(WithDestination(NewWriterDestination(buf))))
+
+	// Test basic masking
+	user := UserCredentials{
+		Username: "john_doe",
+		Password: "secret123",
+		Email:    "john@example.com",
+		APIKey:   "abc123def456ghi789",
+		Token:    "very_secret_token",
+		ID:       12345,
+	}
+
+	logger.Info("User login", "user", user)
+	output := buf.String()
+
+	// Test that password is fully masked
+	if strings.Contains(output, "secret123") {
+		t.Errorf("Password should be masked, but found in output: %s", output)
+	}
+	if !strings.Contains(output, "\"user.password\":\"*********\"") {
+		t.Errorf("Password should be masked with asterisks: %s", output)
+	}
+
+	// Test that email shows first 4 characters
+	if !strings.Contains(output, "\"user.email\":\"john************\"") {
+		t.Errorf("Email should show first 4 characters: %s", output)
+	}
+
+	// Test that API key shows first 8 characters
+	if !strings.Contains(output, "\"user.apikey\":\"abc123de**********\"") {
+		t.Errorf("API key should show first 8 characters: %s", output)
+	}
+
+	// Test that token is fully masked (mask[0])
+	if strings.Contains(output, "very_secret_token") {
+		t.Errorf("Token should be fully masked: %s", output)
+	}
+	if !strings.Contains(output, "\"user.token\":\"*****************\"") {
+		t.Errorf("Token should be fully masked with asterisks: %s", output)
+	}
+
+	// Test that ID (integer) masking works
+	if !strings.Contains(output, "\"user.id\":\"12***\"") {
+		t.Errorf("ID should show first 2 digits: %s", output)
+	}
+
+	// Test that username is not masked (no mask tag)
+	if !strings.Contains(output, "\"user.username\":\"john_doe\"") {
+		t.Errorf("Username should not be masked: %s", output)
+	}
+}
+
+func TestNestedStructMasking(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := New(NewJSONHandler(WithDestination(NewWriterDestination(buf))))
+
+	nested := NestedUser{
+		Name: "John Doe",
+		Credentials: UserCredentials{
+			Username: "admin",
+			Password: "topsecret",
+			Email:    "admin@company.com",
+		},
+		SessionID: "session123456",
+	}
+
+	logger.Info("User session", "user", nested)
+	output := buf.String()
+
+	// Test nested struct masking
+	if strings.Contains(output, "topsecret") {
+		t.Errorf("Nested password should be masked: %s", output)
+	}
+	if !strings.Contains(output, "\"user.credentials.password\":\"*********\"") {
+		t.Errorf("Nested password should be masked with asterisks: %s", output)
+	}
+
+	// Test that top-level field with mask tag works
+	if strings.Contains(output, "session123456") {
+		t.Errorf("SessionID should be masked: %s", output)
+	}
+	if !strings.Contains(output, "\"user.sessionid\":\"*************\"") {
+		t.Errorf("SessionID should be masked with asterisks: %s", output)
+	}
+
+	// Test that non-masked fields are preserved
+	if !strings.Contains(output, "\"user.name\":\"John Doe\"") {
+		t.Errorf("Name should not be masked: %s", output)
+	}
+	if !strings.Contains(output, "\"user.credentials.username\":\"admin\"") {
+		t.Errorf("Nested username should not be masked: %s", output)
+	}
+}
+
+func TestMaskingEdgeCases(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := New(NewJSONHandler(WithDestination(NewWriterDestination(buf))))
+
+	type EdgeCase struct {
+		EmptyString  string  `sawmill:"mask"`
+		ShortString  string  `sawmill:"mask[5]"`
+		ExactLength  string  `sawmill:"mask[3]"`
+		LongerUnmask string  `sawmill:"mask[10]"`
+		NilPointer   *string `sawmill:"mask"`
+	}
+
+	edge := EdgeCase{
+		EmptyString:  "",
+		ShortString:  "ab",
+		ExactLength:  "abc",
+		LongerUnmask: "short",
+	}
+
+	logger.Info("Edge cases", "edge", edge)
+	output := buf.String()
+
+	// Empty string should remain empty when masked
+	if !strings.Contains(output, "\"edge.emptystring\":\"\"") {
+		t.Errorf("Empty string should remain empty: %s", output)
+	}
+
+	// Short string with mask[5] should not be masked (unmask count >= length)
+	if !strings.Contains(output, "\"edge.shortstring\":\"ab\"") {
+		t.Errorf("Short string should not be masked when unmask count >= length: %s", output)
+	}
+
+	// Exact length should not be masked
+	if !strings.Contains(output, "\"edge.exactlength\":\"abc\"") {
+		t.Errorf("String with exact unmask length should not be masked: %s", output)
+	}
+
+	// Longer unmask than string length should not mask
+	if !strings.Contains(output, "\"edge.longerunmask\":\"short\"") {
+		t.Errorf("String with unmask count > length should not be masked: %s", output)
+	}
+}
+
+func TestMaskValueFunction(t *testing.T) {
+	attrs := NewFlatAttributes()
+
+	// Test mask function directly
+	tests := []struct {
+		input    interface{}
+		maskTag  string
+		expected string
+	}{
+		{"password123", "mask", "***********"},
+		{"email@test.com", "mask[5]", "email*********"},
+		{"short", "mask[10]", "short"}, // unmask count >= length
+		{12345, "mask[2]", "12***"},
+		{"", "mask", ""},
+		{"test", "mask[0]", "****"},
+		{"invalid", "invalid_tag", "invalid"},
+		{"test", "", "test"},
+	}
+
+	for i, test := range tests {
+		result := attrs.maskValue(test.input, test.maskTag)
+		if result != test.expected {
+			t.Errorf("Test %d: maskValue(%v, %s) = %v, expected %v",
+				i, test.input, test.maskTag, result, test.expected)
+		}
+	}
+}
+
+func TestMaskingWithDifferentFormatters(t *testing.T) {
+	user := UserCredentials{
+		Username: "testuser",
+		Password: "secret",
+		Email:    "test@example.com",
+	}
+
+	// Test with Text formatter
+	buf := &bytes.Buffer{}
+	textLogger := New(NewTextHandler(WithDestination(NewWriterDestination(buf))))
+	textLogger.Info("Text test", "user", user)
+	textOutput := buf.String()
+
+	if strings.Contains(textOutput, "secret") {
+		t.Errorf("Text formatter should mask password: %s", textOutput)
+	}
+	if !strings.Contains(textOutput, "password: ******") {
+		t.Errorf("Text formatter should show masked password: %s", textOutput)
+	}
+
+	// Test with KeyValue formatter
+	buf.Reset()
+	kvLogger := New(NewKeyValueHandler(WithDestination(NewWriterDestination(buf))))
+	kvLogger.Info("KeyValue test", "user", user)
+	kvOutput := buf.String()
+
+	if strings.Contains(kvOutput, "secret") {
+		t.Errorf("KeyValue formatter should mask password: %s", kvOutput)
+	}
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,404 @@
+package sawmill
+
+import (
+	"bytes"
+	"os"
+	"testing"
+	"time"
+)
+
+func TestHandlerOptions(t *testing.T) {
+	buf := &bytes.Buffer{}
+	dest := NewWriterDestination(buf)
+
+	options := []HandlerOption{
+		WithDestination(dest),
+		WithLevel(LevelWarn),
+		WithTimeFormat("2006-01-02"),
+		WithSourceInfo(true),
+		WithLevelInfo(false),
+		WithAttributeFormat("flat"),
+		WithPrettyPrint(true),
+		WithAttributesKey("custom_attrs"),
+		WithColorsEnabled(true),
+		WithColorMappings(map[string]string{"user": "red"}),
+	}
+
+	handlerOpts := NewHandlerOptions(options...)
+
+	// Test all options were applied
+	if handlerOpts.destination != dest {
+		t.Error("Destination option not applied")
+	}
+	if handlerOpts.level != LevelWarn {
+		t.Error("Level option not applied")
+	}
+	if handlerOpts.timeFormat != "2006-01-02" {
+		t.Error("TimeFormat option not applied")
+	}
+	if !handlerOpts.includeSource {
+		t.Error("IncludeSource option not applied")
+	}
+	if handlerOpts.includeLevel {
+		t.Error("IncludeLevel option not applied")
+	}
+	if handlerOpts.attrFormat != "flat" {
+		t.Error("AttributeFormat option not applied")
+	}
+	if !handlerOpts.prettyPrint {
+		t.Error("PrettyPrint option not applied")
+	}
+	if handlerOpts.attributesKey != "custom_attrs" {
+		t.Error("AttributesKey option not applied")
+	}
+	if !handlerOpts.enableColors {
+		t.Error("ColorsEnabled option not applied")
+	}
+	if handlerOpts.colorMappings["user"] != "red" {
+		t.Error("ColorMappings option not applied")
+	}
+}
+
+func TestSawmillOptions(t *testing.T) {
+	sawmillOpts := &SawmillOptions{
+		LogLevel: "debug",
+		LogFile:  "test.log",
+		MaxSize:  100,
+	}
+
+	options := []HandlerOption{
+		WithSawmillOptions(sawmillOpts),
+	}
+
+	handlerOpts := NewHandlerOptions(options...)
+
+	if handlerOpts.sawmillOpts != sawmillOpts {
+		t.Error("SawmillOptions not applied")
+	}
+}
+
+func TestWithWriter(t *testing.T) {
+	buf := &bytes.Buffer{}
+	
+	handler := NewTextHandler(WithWriter(buf))
+	logger := New(handler)
+	
+	logger.Info("Test message")
+	
+	output := buf.String()
+	if output == "" {
+		t.Error("WithWriter option should route output to provided writer")
+	}
+}
+
+func TestDefaultHandlerOptions(t *testing.T) {
+	opts := NewHandlerOptions()
+
+	// Test defaults
+	if opts.level != LevelInfo {
+		t.Errorf("Expected default level Info, got %v", opts.level)
+	}
+	if opts.timeFormat != time.RFC3339 {
+		t.Errorf("Expected default time format RFC3339, got %s", opts.timeFormat)
+	}
+	if !opts.includeSource {
+		t.Error("Expected default includeSource to be true")
+	}
+	if !opts.includeLevel {
+		t.Error("Expected default includeLevel to be true")
+	}
+	if opts.attrFormat != "nested" {
+		t.Errorf("Expected default attribute format nested, got %s", opts.attrFormat)
+	}
+	if opts.prettyPrint {
+		t.Error("Expected default prettyPrint to be false")
+	}
+	if opts.attributesKey != "attributes" {
+		t.Errorf("Expected default attributes key 'attributes', got %s", opts.attributesKey)
+	}
+	if opts.enableColors {
+		t.Error("Expected default enableColors to be false")
+	}
+	if opts.colorOutput {
+		t.Error("Expected default colorOutput to be false")
+	}
+}
+
+func TestMultipleOptionsOfSameType(t *testing.T) {
+	// Test that later options override earlier ones
+	options := []HandlerOption{
+		WithLevel(LevelDebug),
+		WithLevel(LevelError), // This should override the first one
+		WithTimeFormat("2006-01-02"),
+		WithTimeFormat("15:04:05"), // This should override the first one
+	}
+
+	opts := NewHandlerOptions(options...)
+
+	if opts.level != LevelError {
+		t.Errorf("Expected level Error (last one), got %v", opts.level)
+	}
+	if opts.timeFormat != "15:04:05" {
+		t.Errorf("Expected time format '15:04:05' (last one), got %s", opts.timeFormat)
+	}
+}
+
+func TestOptionsWithRealHandlers(t *testing.T) {
+	buf := &bytes.Buffer{}
+
+	// Test TextHandler with options
+	textHandler := NewTextHandler(
+		WithDestination(NewWriterDestination(buf)),
+		WithLevel(LevelWarn),
+		WithSourceInfo(false),
+		WithAttributeFormat("flat"),
+	)
+
+	logger := New(textHandler)
+	
+	// This should not appear (below warn level)
+	logger.Info("Info message")
+	if buf.Len() > 0 {
+		t.Error("Info message should not appear with Warn level")
+	}
+
+	// This should appear
+	logger.Error("Error message")
+	output := buf.String()
+	if output == "" {
+		t.Error("Error message should appear with Warn level")
+	}
+
+	// Test JSONHandler with options
+	buf.Reset()
+	jsonHandler := NewJSONHandler(
+		WithDestination(NewWriterDestination(buf)),
+		WithPrettyPrint(true),
+		WithAttributesKey("data"),
+	)
+
+	logger = New(jsonHandler)
+	logger.Info("JSON message", "key", "value")
+	
+	jsonOutput := buf.String()
+	if jsonOutput == "" {
+		t.Error("JSON handler should produce output")
+	}
+	// Should be pretty printed (contains indentation)
+	if !containsIndentation(jsonOutput) {
+		t.Error("JSON should be pretty printed")
+	}
+	// Should use custom attributes key
+	if !containsString(jsonOutput, "data") {
+		t.Error("JSON should use custom attributes key")
+	}
+}
+
+func TestOptionsBuilderPattern(t *testing.T) {
+	// Test that options can be built in a fluent style
+	buf := &bytes.Buffer{}
+	
+	handler := NewJSONHandler(
+		WithDestination(NewWriterDestination(buf)),
+		WithLevel(LevelDebug),
+		WithTimeFormat("2006-01-02 15:04:05"),
+		WithSourceInfo(true),
+		WithPrettyPrint(true),
+		WithAttributesKey("attrs"),
+		WithColorsEnabled(false),
+	)
+
+	if handler == nil {
+		t.Fatal("Handler should not be nil")
+	}
+
+	logger := New(handler)
+	logger.Info("Test message", "test", "value")
+
+	output := buf.String()
+	if output == "" {
+		t.Error("Handler with multiple options should produce output")
+	}
+}
+
+func TestColorMappingsOption(t *testing.T) {
+	colorMappings := map[string]string{
+		"user":    "\033[32m", // green
+		"error":   "\033[31m", // red
+		"request": "\033[34m", // blue
+	}
+
+	buf := &bytes.Buffer{}
+	handler := NewTextHandler(
+		WithDestination(NewWriterDestination(buf)),
+		WithColorMappings(colorMappings),
+		WithColorsEnabled(true),
+	)
+
+	logger := New(handler)
+	logger.Info("Test message", "user", "john", "error", "none")
+
+	output := buf.String()
+	// Should contain ANSI color codes when colors are enabled
+	if !containsString(output, "\033[") {
+		t.Error("Output should contain ANSI color codes")
+	}
+}
+
+func TestSawmillOptionsIntegration(t *testing.T) {
+	// Create a temporary file for testing
+	tmpFile := "test_sawmill.log"
+	defer os.Remove(tmpFile)
+
+	sawmillOpts := &SawmillOptions{
+		LogLevel: "warn",
+		LogFile:  tmpFile,
+		MaxSize:  1, // 1MB
+	}
+
+	handler := NewTextHandler(WithSawmillOptions(sawmillOpts))
+	logger := New(handler)
+
+	// This should not appear (info < warn)
+	logger.Info("Info message")
+
+	// This should appear
+	logger.Error("Error message")
+
+	// Check that file was created (though we can't easily verify content without more setup)
+	if _, err := os.Stat(tmpFile); os.IsNotExist(err) {
+		// File creation might fail in test environment, that's ok
+		t.Logf("File creation failed (expected in test): %v", err)
+	}
+}
+
+// Helper functions for tests
+
+func containsIndentation(s string) bool {
+	return containsString(s, "  ") || containsString(s, "\t")
+}
+
+func containsString(s, substr string) bool {
+	return len(s) > 0 && len(substr) > 0 && 
+		   findSubstring(s, substr) != -1
+}
+
+func findSubstring(s, substr string) int {
+	if len(substr) == 0 {
+		return 0
+	}
+	if len(substr) > len(s) {
+		return -1
+	}
+	
+	for i := 0; i <= len(s)-len(substr); i++ {
+		match := true
+		for j := 0; j < len(substr); j++ {
+			if s[i+j] != substr[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestOptionsOrderIndependence(t *testing.T) {
+	buf1 := &bytes.Buffer{}
+	buf2 := &bytes.Buffer{}
+
+	// Create two handlers with same options in different order
+	handler1 := NewTextHandler(
+		WithDestination(NewWriterDestination(buf1)),
+		WithLevel(LevelDebug),
+		WithTimeFormat("2006-01-02"),
+		WithSourceInfo(true),
+	)
+
+	handler2 := NewTextHandler(
+		WithSourceInfo(true),
+		WithTimeFormat("2006-01-02"),
+		WithLevel(LevelDebug),
+		WithDestination(NewWriterDestination(buf2)),
+	)
+
+	logger1 := New(handler1)
+	logger2 := New(handler2)
+
+	// Both should behave the same
+	logger1.Debug("Test message")
+	logger2.Debug("Test message")
+
+	// Both should produce output (debug level enabled)
+	if buf1.Len() == 0 || buf2.Len() == 0 {
+		t.Error("Both handlers should produce output regardless of option order")
+	}
+}
+
+func TestNilOptionsHandling(t *testing.T) {
+	// Test that nil options don't cause panics
+	var nilOptions []HandlerOption
+	opts := NewHandlerOptions(nilOptions...)
+
+	if opts == nil {
+		t.Error("NewHandlerOptions should handle nil options")
+	}
+
+	// Test handler creation with no options
+	handler := NewTextHandler()
+	if handler == nil {
+		t.Error("Handler should be created even with no options")
+	}
+
+	logger := New(handler)
+	logger.Info("Test message") // Should not panic
+}
+
+func TestInvalidOptionValues(t *testing.T) {
+	// Test with empty/invalid values
+	handler := NewTextHandler(
+		WithTimeFormat(""), // Empty time format
+		WithAttributeFormat("invalid"), // Invalid attribute format
+		WithAttributesKey(""), // Empty attributes key
+	)
+
+	if handler == nil {
+		t.Error("Handler should handle invalid option values gracefully")
+	}
+
+	logger := New(handler)
+	logger.Info("Test message") // Should not panic
+}
+
+func TestOptionsCombinations(t *testing.T) {
+	// Test various combinations of options work together
+	testCases := [][]HandlerOption{
+		{WithLevel(LevelTrace), WithSourceInfo(true)},
+		{WithPrettyPrint(true), WithAttributesKey("custom")},
+		{WithColorsEnabled(true), WithAttributeFormat("flat")},
+		{WithTimeFormat("15:04:05"), WithLevelInfo(false)},
+	}
+
+	for i, options := range testCases {
+		t.Run(string(rune('A'+i)), func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			baseOptions := []HandlerOption{WithDestination(NewWriterDestination(buf))}
+			allOptions := append(baseOptions, options...)
+
+			handler := NewJSONHandler(allOptions...)
+			if handler == nil {
+				t.Errorf("Handler creation failed for option set %d", i)
+			}
+
+			logger := New(handler)
+			logger.Info("Test message", "key", "value")
+
+			if buf.Len() == 0 {
+				t.Errorf("No output produced for option set %d", i)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces masking functionality for sensitive data fields, enhances struct handling in logging, and adds comprehensive tests for the new features. The most significant changes include implementing a new masking mechanism using `sawmill` tags, updating the logger to support struct expansion and masking, and adding extensive test coverage for both masking and logging functionalities.

### Masking Functionality
* Added a `maskValue` function in `flat_attributes.go` to apply masking based on `sawmill` tags. Supports full masking (`mask`) and partial masking (`mask[n]`) for strings and integers.
* Updated `ExpandStruct` in `flat_attributes.go` to apply masking rules when expanding structs with `sawmill` tags.

### Logger Enhancements
* Introduced `shouldExpandStruct` in `logger.go` to determine if a value should be expanded as a struct. Updated `processArgsOptimized` to handle struct expansion and apply masking. [[1]](diffhunk://#diff-ff87b7c4777a35588053a509583d66c9f404ccbea9e1c71d2a5f224d7ad1323eL153-R163) [[2]](diffhunk://#diff-ff87b7c4777a35588053a509583d66c9f404ccbea9e1c71d2a5f224d7ad1323eR184-R211)

### Examples and Test Coverage
* Added a new example in `examples/masking/main.go` demonstrating the use of `sawmill` tags for masking sensitive fields.
* Created `masking_test.go` with tests for various masking scenarios, including edge cases, nested structs, and different formatters.
* Enhanced `logger_test.go` with tests for struct expansion, nested attributes, and logger functionalities.

### Minor Changes
* Added necessary imports for `regexp` and `strconv` in `flat_attributes.go` to support the masking logic.
* Removed redundant newline in `examples/http-plugin/main.go` for cleaner output.